### PR TITLE
add request loaded event

### DIFF
--- a/lib/BaseService.js
+++ b/lib/BaseService.js
@@ -3,22 +3,22 @@
  * @description Base class for services.  Adds promise based request with helpers for
  * checking the store to see if a object is already loaded.  Also has wrapper for checking
  * response for errors, rejecting promise if error condition is tripped.
- * 
+ *
  * Most methods making a request should return the promise so other Models/Elements can bind
  * to the handling of the promise
- * 
+ *
  * Example:
- * 
+ *
  * import MyStore from '../stores/MyStore';
- * 
+ *
  * class MyService extends BaseService {
- *  
+ *
  *   constructor() {
  *     super();
  *     this.store = MyStore;
  *   }
- * 
- *   async doCoolThing(id) {     
+ *
+ *   async doCoolThing(id) {
  *     return await this.request({
  *       request : {
  *         method : 'GET',
@@ -30,9 +30,9 @@
  *       onError : (err) => this.store.setCoolThingError(err)
  *     });
  *   }
- * 
+ *
  * }
- * 
+ *
  */
 class BaseService {
 
@@ -63,7 +63,7 @@ class BaseService {
    * @method request
    * @description Help make service calls updating store w/ result.  All parameters are optional
    * but the request parameter.
-   * 
+   *
    * @param {Object} options
    * @param {Object} options.url - request url
    * @param {Object} options.fetchOptions - fetch api options
@@ -75,7 +75,7 @@ class BaseService {
    * @param {Function} options.onError - Store class method to call onError
    * @param {Function} options.onLoad - Store class method to call onLoad
    * @param {Function} options.onUpdate - Called after onLoading, onError, onLoad
-   * 
+   *
    * @returns {Promise}
    */
   async request(options) {
@@ -92,11 +92,11 @@ class BaseService {
     }
 
     // if json flag, stringify body, set content type
-    if( options.json && 
+    if( options.json &&
         options.fetchOptions &&
         options.fetchOptions.body &&
         typeof options.fetchOptions.body === 'object') {
-  
+
       options.fetchOptions.body = JSON.stringify(options.fetchOptions.body);
       if( !options.fetchOptions.headers ) options.fetchOptions.headers = {};
       options.fetchOptions.headers['Content-Type'] = 'application/json'
@@ -117,7 +117,7 @@ class BaseService {
 
       if( this.isLoaded(cachedObject) ) {
         return cachedObject;
-      
+
       // return stored promise if loading
       } else if( this.isLoading(cachedObject) ) {
         if( !cachedObject.request ) {
@@ -147,9 +147,9 @@ class BaseService {
       } catch(e) {
         return this._handleError(
           options, resolve,
-          { 
-            error: true, 
-            details: e, 
+          {
+            error: true,
+            details: e,
             response,
             message: this.ERROR_MESSAGES.REQUEST
           }
@@ -159,17 +159,17 @@ class BaseService {
       if( response.status < 200 || response.status > 299 ) {
         return this._handleError(
           options, resolve,
-          { 
-            error: true, 
-            response: response, 
+          {
+            error: true,
+            response: response,
             message: this.ERROR_MESSAGES.STATUS_CODE
           }
         );
       }
 
-      if( response.headers.has('Content-Type') && 
+      if( response.headers.has('Content-Type') &&
         response.headers.get('Content-Type').match(/application\/json/i) ) {
-        
+
         var body = null;
         try {
           body = await response.text();
@@ -177,8 +177,8 @@ class BaseService {
         } catch(e) {
           return this._handleError(
             options, resolve,
-            { 
-              error: true, 
+            {
+              error: true,
               details: e,
               response: response,
               message: this.ERROR_MESSAGES.JSON
@@ -197,8 +197,8 @@ class BaseService {
         if( body.error ) {
           return this._handleError(
             options, resolve,
-            { 
-              error: true, 
+            {
+              error: true,
               details: body,
               response : response,
               message: this.ERROR_MESSAGES.APPLICATION_ERROR
@@ -219,7 +219,7 @@ class BaseService {
     if( error.response && !error.payload ) {
       try {
         error.payload = await error.response.text();
-        if( error.response.headers.has('Content-Type') && 
+        if( error.response.headers.has('Content-Type') &&
           error.response.headers.get('Content-Type').match(/application\/json/i) ) {
           try {
             error.payload = JSON.parse(error.payload);
@@ -256,7 +256,7 @@ class BaseService {
     if( !this.store ) {
       return console.warn('Checking LOADED state but no store set for service');
     }
-    
+
     if( object && object.state === this.store.STATE.LOADING ) {
       return true;
     }
@@ -268,11 +268,11 @@ class BaseService {
    * @description Helper method to check if object is already requesting, if so
    * wait for request to finish before proceeding. If not requesting, call request
    * method.
-   * 
+   *
    * @param {String} id - id of object to check
    * @param {Object} store - store object to check
    * @param {Function} request - request method to call if object not requesting
-   * 
+   *
    * @returns {Promise}
    */
   async checkRequesting(id, store, request) {
@@ -282,6 +282,26 @@ class BaseService {
       await item.request;
     } else {
       await request();
+    }
+  }
+
+  /**
+   * @description Helper method to emit event if object is loaded in store - even if cached
+   * @param {String} id - id of object to emit
+   * @param {Object} store - store object to check for id
+   * @param {String} eventName - event name to emit. defaults to store name + '-request-loaded'
+   */
+  emitIfLoaded(id, store, eventName){
+    if( !store ) {
+      throw new Error('Cannot emit event request loaded without a store');
+    }
+    if( !eventName ) {
+      eventName = store.name.replace(/[\s\._]/g, '-').toLowerCase() + '-request-loaded';
+    }
+
+    const payload = store.get(id);
+    if ( this.isLoaded(payload) ) {
+      this.store.emit(eventName, payload);
     }
   }
 

--- a/lib/BaseStore.js
+++ b/lib/BaseStore.js
@@ -5,54 +5,54 @@ import STATES from './states.js';
 
 /**
  * @class BaseStore
- * @description All stores should extend this class.  It really provides two simple 
+ * @description All stores should extend this class.  It really provides two simple
  * things.  First a emit() method for firing events that are async.  Second, it
  * provides standard STATE names for data payload wrappers.  Store data in similar way
  * really helps the reactive side of the app.
- * 
+ *
  * Example
- * 
+ *
  * class MyStore extends BaseStore {
- * 
+ *
  *   constructor() {
  *     super();
- *     
+ *
  *     this.data = {
  *       aSingleThing : {
  *         state : this.STATE.INIT
  *       }
  *     }
- *     
+ *
  *     // these events will be automatically bound to elements
  *     this.events = {
  *       THING_UPDATED : 'thing-updated'
  *     }
  *   }
- *   
+ *
  *   // promise is the request promise
  *   setThingLoading(promise) {
  *      this.updateThing({state: this.STATE.LOADING, request: promise});
  *   }
- * 
+ *
  *   setThingLoaded(newData) {
  *      this.updateThing({state: this.STATE.LOADED, payload: newData});
  *   }
- * 
+ *
  *   setThingError(err) {
  *      this.updateThing({state: this.STATE.ERROR, error: err});
  *   }
- *   
+ *
  *   // actually set data state and fire event
  *   updateThing(data) {
  *     // new state is same as old state, just quit out
  *     if( !this.stateChanged(this.data.aSingleThing, data) ) return;
- * 
+ *
  *     this.data.aSingleThing = data;
  *     this.emit(this.events.THING_UPDATED, this.data.aSingleThing);
  *   }
- * 
+ *
  * }
- * 
+ *
  */
 class BaseStore {
 
@@ -70,10 +70,13 @@ class BaseStore {
     for( let key in this.data ) {
       if( this.data[key] instanceof LruStore ) {
         let name = this.data[key].name;
-        let event = name.replace(/[\s\._]/g, '-').toLowerCase()+ '-update';
-        let eventKey = event.replace(/-/g, '_').toUpperCase();
-        if( !this.events[eventKey] ) {
-          this.events[eventKey] = event;
+        let events = ['update', 'request-loaded'];
+        for( let event of events ) {
+          let eventName = name.replace(/[\s\._]/g, '-').toLowerCase() + '-' + event;
+          let eventKey = eventName.replace(/-/g, '_').toUpperCase();
+          if( !this.events[eventKey] ) {
+            this.events[eventKey] = eventName;
+          }
         }
       }
     }
@@ -86,9 +89,9 @@ class BaseStore {
   /**
    * @method set
    * @description Set data in a store.  This is a simple wrapper around the store's set
-   * method.  It enforces that the payload has an id and state and that the store is 
+   * method.  It enforces that the payload has an id and state and that the store is
    * passed
-   * 
+   *
    * @param {Object} payload required
    * @param {LruStore} store LruStore object
    * @param {String} eventName optional event name to fire.  Defaults to store name + '-updated'
@@ -108,14 +111,14 @@ class BaseStore {
     if( !eventName ) {
       eventName = store.name.replace(/[\s\._]/g, '-').toLowerCase() + '-update';
     }
-    
+
     this.emit(eventName, payload);
   }
 
   /**
    * @method emit
    * @description Fire a async event on EventBus event bus.
-   * 
+   *
    * @param {String} event event name
    * @param {Object} payload event payload
    */
@@ -130,10 +133,10 @@ class BaseStore {
    * @method stateChanged
    * @description given two state objects, check there is a difference
    * between them.  This is a deep check, not a direct object comparison.
-   * 
+   *
    * @param {Object} currentState objects currently store state
    * @param {Object} newState new state for object
-   * 
+   *
    * @returns {Boolean}
    */
   stateChanged(currentState, newState) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucd-lib/cork-app-utils",
-  "version": "6.2.6",
+  "version": "6.2.7",
   "description": "Base classes for wiring client app code to event framework",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
# Summary

- auto-registers additional event in store for each lru, with `-request-loaded` suffix.
- adds method to service that allows user to emit this event.

# Example
```js
class FooService extends BaseService {

  constructor() {
    super();
    this.store = FooStore;
    this.basePath = `${appConfig.apiRoot}/foo`;
  }

  async list(){
    let ido = {action: 'list'};
    let id = payload.getKey(ido);

    await this.checkRequesting(
      id, this.store.data.list,
      () => this.request({
        url : this.basePath,
        checkCached : () => this.store.data.list.get(id),
        onUpdate : resp => this.store.set(
          payload.generate(ido, resp),
          this.store.data.list
        )
      })
    );

    // new method 
    this.emitIfLoaded(id, this.store.data.list);

    return this.store.data.list.get(id);
  }


}
```

Element then can listen via `_onFooListRequestLoaded` method

# Utility
This is mostly useful when doing code-splitting. If data are retrieved by an element in chunk A, and then chunk B is loaded that has an element that needs that data, it's `_onFooListUpdate` event won't fire since the data has already been set in the cache.

Although, maybe a better pattern would be to call the callback in the element constructor. e.g.
```js
this._onFooListUpdate(this.FooModel.store.data.list.get(payloadUtils.getKey({action: 'list'}))
```